### PR TITLE
chore(ci): remove legacy vercel-action; rely on Vercel Git integration; add tests-only CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm test -- --run


### PR DESCRIPTION
## Summary
Removed dependency on legacy GitHub Action deploy that required VERCEL_TOKEN and added a clean tests-only CI workflow relying on Vercel's native Git integration.

## Changes Made

### ✅ **Removed Legacy Deploy Workflow**
- Searched for `amondnet/vercel-action` and Vercel deploy workflows
- **Result**: No legacy workflow found - appears to have been removed in previous commit `e5a8868 ci: remove custom Vercel deploy actions; use native Git integration only`

### ✅ **Added Tests-Only CI Workflow**
- **File**: `.github/workflows/ci.yml`
- **Triggers**: Pull requests and pushes to main
- **Jobs**: TypeScript type checking and Vitest tests
- **Node Version**: 20 (latest LTS)

```yaml
name: CI
on:
  pull_request:
  push:
    branches: [main]
jobs:
  test:
    runs-on: ubuntu-latest
    defaults:
      run:
        working-directory: frontend
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-node@v4
        with:
          node-version: '20'
      - run: npm ci
      - run: npm run typecheck
      - run: npm test -- --run
```

## Benefits
- **No more deployment failures** due to missing `VERCEL_TOKEN`
- **Cleaner CI/CD pipeline** - Vercel Git integration handles deployments automatically
- **Faster feedback** - Only runs essential tests and type checking
- **No authentication dependencies** - Works without requiring secret management

## Manual Test Checklist
- [ ] Verify CI runs successfully on this PR
- [ ] Test Vercel preview deployment works (should auto-deploy via Git integration)
- [ ] Run health check: `curl https://<preview-url>/api/healthz`
- [ ] Run tests against preview: `BASE_URL=https://<preview-url> npm test`
- [ ] Confirm no deployment workflow conflicts

## Next Steps
1. Merge this PR to enable clean CI
2. Verify production deploys work via Vercel Git integration
3. Remove any remaining deployment secrets if no longer needed

🤖 Generated with [Claude Code](https://claude.ai/code)